### PR TITLE
Don't create new instances

### DIFF
--- a/src/main/java/hu/ssh/progressbar/AbstractProgressBar.java
+++ b/src/main/java/hu/ssh/progressbar/AbstractProgressBar.java
@@ -1,7 +1,7 @@
 package hu.ssh.progressbar;
 
 public abstract class AbstractProgressBar<T extends AbstractProgressBar<?>> implements ProgressBar<T> {
-	protected final long totalSteps;
+	protected long totalSteps;
 
 	private long actualSteps = 0;
 	private long startTime = 0;

--- a/src/main/java/hu/ssh/progressbar/console/ConsoleProgressBar.java
+++ b/src/main/java/hu/ssh/progressbar/console/ConsoleProgressBar.java
@@ -56,9 +56,9 @@ public final class ConsoleProgressBar extends AbstractProgressBar<ConsoleProgres
 	public static final int DEFAULT_PROGRESSBAR_WIDTH = 60;
 	private static final Set<Replacer> DEFAULT_REPLACERS = getDefaultReplacers(DEFAULT_PROGRESSBAR_WIDTH);
 
-	private final Set<Replacer> replacers;
+	private Set<Replacer> replacers;
 	private final PrintStream streamToUse;
-	private final String outputFormat;
+	private String outputFormat;
 
 	private int previousLength = 0;
 
@@ -101,20 +101,16 @@ public final class ConsoleProgressBar extends AbstractProgressBar<ConsoleProgres
 	public ConsoleProgressBar withFormat(final String outputFormat) {
 		Preconditions.checkNotNull(outputFormat);
 
-		return new ConsoleProgressBar(streamToUse,
-				totalSteps,
-				outputFormat,
-				replacers);
+		this.outputFormat = outputFormat;
+		return this;
 	}
 
 	@Override
 	public ConsoleProgressBar withTotalSteps(final int totalSteps) {
 		Preconditions.checkArgument(totalSteps != 0);
 
-		return new ConsoleProgressBar(streamToUse,
-				totalSteps,
-				outputFormat,
-				replacers);
+		this.totalSteps = totalSteps;
+		return this;
 	}
 
 	/**
@@ -127,10 +123,8 @@ public final class ConsoleProgressBar extends AbstractProgressBar<ConsoleProgres
 	public ConsoleProgressBar withReplacers(final Collection<Replacer> replacers) {
 		Preconditions.checkNotNull(replacers);
 
-		return new ConsoleProgressBar(streamToUse,
-				totalSteps,
-				outputFormat,
-				ImmutableSet.copyOf(replacers));
+		this.replacers = ImmutableSet.copyOf(replacers);
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
Instead of creating new instances, the instance methods to change the total steps, the format and the replacers should modify the current instance. This makes things more convenient when you have to manage multiple references to the same progress bar across an application and the number steps, format or replacers are not known before instantiating the progress bar.
